### PR TITLE
Add requirements to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ $> make deps
 $> make
 ```
 
+### Requirements
+
+* OpenGL see [github.com/faiface/glhf](https://github.com/faiface/glhf#which-version-of-opengl-does-glhf-use)
+* [github.com/faiface/pixel](https://github.com/faiface/pixel#requirements)
+* [github.com/go-gl/glfw/v3.2/glfw](https://github.com/go-gl/glfw#installation)
+* `go>=1.8.1`
+
 ## Running
 
 


### PR DESCRIPTION
This PR adds a "requirements" section to the README.

Requirements consist in urls pointing to requirements sections of each go package used in this project.

`go>=1.8.1` refers to <https://github.com/faiface/pixel#requirements> ?

> The combination of Go 1.8, macOS and latest XCode seems to be problematic as mentioned in issue #7. This issue is probably not related to Pixel. Upgrading to Go 1.8.1 fixes the issue.